### PR TITLE
NSGregorianCalendarをNSCalendarIdentifierGregorianに変更

### DIFF
--- a/Webpay/CardForm/Field/ExpiryPicker/WPYExpiryPickerView.m
+++ b/Webpay/CardForm/Field/ExpiryPicker/WPYExpiryPickerView.m
@@ -137,7 +137,7 @@ typedef NS_ENUM(NSInteger, WPYComponents)
 - (NSInteger)currentYear
 {
     NSDate *now = [NSDate date];
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDateComponents *comps = [calendar components:NSCalendarUnitYear fromDate:now];
     return comps.year;
 }


### PR DESCRIPTION
Xcode7で警告が出るので非推奨のNSGregorianCalendarをNSCalendarIdentifierGregorianに変更しました。