### PR TITLE
Use valid calendar identifier for each ios version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can either install using cocoapods(recommended) or copying files manually.
 ### 1. Cocoapods(Recommended)
 In your Podfile, add a line
 ```
-pod 'WebPay', '~> 2.0'
+pod 'WebPay', '~> 2.0.1'
 ```
 then, run `pod install`.
 

--- a/WebPay.podspec
+++ b/WebPay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WebPay"
-  s.version      = "2.0"
+  s.version      = "2.0.1"
   s.summary      = "Tokenizer library for WebPay.jp"
   s.description  = <<-DESC
                    WebPay.jp is an API for accepting online payments in Japan.
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { "yohei okada" => "okada.yohei@gmail.com" }
   s.platform     = :ios
   s.ios.deployment_target = "7.0"
-  s.source       = { :git => "https://github.com/webpay/webpay-token-ios.git", :tag => '2.0' }
+  s.source       = { :git => "https://github.com/webpay/webpay-token-ios.git", :tag => s.version.to_s }
   s.source_files  = "Webpay/**/*.{h,m}"
   s.resources = ["Webpay/Resources/WebPay.bundle", "Webpay/Resources/*.{storyboard}"]
   s.frameworks = "Foundation", "UIKit", "QuartzCore"

--- a/Webpay/CardForm/Field/ExpiryPicker/WPYExpiryPickerView.m
+++ b/Webpay/CardForm/Field/ExpiryPicker/WPYExpiryPickerView.m
@@ -137,7 +137,12 @@ typedef NS_ENUM(NSInteger, WPYComponents)
 - (NSInteger)currentYear
 {
     NSDate *now = [NSDate date];
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendar *calendar;
+#ifdef __IPHONE_8_0
+    calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+#else
+    calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
+#endif
     NSDateComponents *comps = [calendar components:NSCalendarUnitYear fromDate:now];
     return comps.year;
 }


### PR DESCRIPTION
NSGregorianCalendar has been deprecated in ios8.
Use NSCalendarIdentifierGregorian for ios8+, and 
use NSGregorianCalendar for ios7 and before.