### PR TITLE
load storyboard from Webpay library

### DIFF
--- a/Webpay/PaymentViewController/WPYPaymentViewController.m
+++ b/Webpay/PaymentViewController/WPYPaymentViewController.m
@@ -112,7 +112,7 @@ static UIImage *imageFromColor(UIColor *color)
                                                        callback:(WPYPaymentViewCallback)callback
 {
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"WebPay"
-                                                         bundle:nil];
+                                                         bundle:[NSBundle bundleForClass:[self class]]];
     WPYPaymentViewController *vc = (WPYPaymentViewController *)[storyboard instantiateInitialViewController];
     vc.priceTag = priceTag;
     vc.card = card;


### PR DESCRIPTION
App could not find storyboard "Webpay", when I installed Webpay 2.0.2 from cocoapods.
I think your library should load storyboard from bundle where library exists.

Please review.